### PR TITLE
feat: isolate Wilma dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,6 @@ classifiers = [
 ]
 keywords = ["debugging", "testing", "development"]
 
-dependencies = [
-  "ddtrace~=1.9",
-  "toml~=0.10.2",
-  "envier~=0.4",
-  "bytecode~=0.13.0",
-  "watchdog~=2.1.9",
-]
 requires-python = ">=3.7"
 
 dynamic = ["version"]
@@ -46,6 +39,9 @@ allow-direct-references = true
 dependencies = [
   "pytest>=6.2.5",
   "pytest-cov>=3.0.0",
+  "toml~=0.10.2",
+  "envier~=0.4",
+  "watchdog~=2.1.9",
 ]
 template = "tests"
 

--- a/tests/target_watch.py
+++ b/tests/target_watch.py
@@ -9,7 +9,7 @@ def say(word="default"):
 def target():
     for _ in range(15):
         say()
-        sleep(0.1)
+        sleep(0.2)
 
 
 thread = Thread(target=target)

--- a/wilma/__init__.py
+++ b/wilma/__init__.py
@@ -1,15 +1,33 @@
+import sys
+from pathlib import Path
+
 import pkg_resources
 
-from wilma._tools import framestack
-from wilma._tools import locals
-from wilma._tools import capture
-from wilma._tools import watch
 
+# Determine if we are preloading Wilma. We expect dependencies to be available
+# in this case.
+PRELOAD = False
+
+frame = sys._getframe()
+while frame:
+    if Path(frame.f_code.co_filename).name == "preload.py":
+        PRELOAD = True
+        break
+    frame = frame.f_back
+
+try:
+    from wilma._tools import capture
+    from wilma._tools import framestack
+    from wilma._tools import locals
+    from wilma._tools import watch
+
+    __all__ = ["framestack", "locals", "capture", "watch"]
+
+except ImportError as e:
+    if PRELOAD:
+        raise
 
 try:
     __version__ = pkg_resources.get_distribution(__name__).version
 except pkg_resources.DistributionNotFound:
     __version__ = "dev"
-
-
-__all__ = ["framestack", "locals", "capture", "watch"]

--- a/wilma/_bootstrap/preload.py
+++ b/wilma/_bootstrap/preload.py
@@ -2,18 +2,63 @@ import atexit
 import json
 import logging
 import os
+import site
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-
-from ddtrace.debugging._debugger import DebuggerModuleWatchdog
-
-import wilma._bootstrap.run_module  # noqa
-from wilma._config import wilmaenv
-from wilma._inject import on_config_changed
+from subprocess import check_output
 
 
 LOGGER = logging.getLogger(__name__)
+
+WILMAPREFIX = Path(os.getenv("WILMAPREFIX", ".wilma"))
+DEPS = WILMAPREFIX / "deps"
+if not DEPS.exists():
+    # Install Wilma dependencies in isolation
+    dependencies = [
+        "ddtrace~=1.9",
+        "toml~=0.10.2",
+        "envier~=0.4",
+        "bytecode~=0.13.0; python_version<'3.8'",
+        "bytecode~=0.14.0; python_version>='3.8'",
+        "watchdog~=2.1.9",
+    ]
+    try:
+        env = dict(os.environ)
+
+        # Create a virtual environment to completely isolate Wilma's
+        # dependencies.
+        env["PYTHONPATH"] = ""
+        check_output(
+            [sys.executable, "-m", "venv", str(DEPS.resolve())],
+            env=env,
+        )
+        check_output(
+            [
+                str(DEPS / "bin" / "python"),
+                "-m",
+                "pip",
+                "install",
+                "--prefix",
+                str(DEPS.resolve()),
+                "--no-input",
+                "--no-python-version-warning",
+            ]
+            + dependencies,
+            env=env,
+        )
+    except Exception:
+        LOGGER.error("Failed to install dependencies", exc_info=True)
+        raise
+
+# Add Wilma dependencies to the path
+wilma_deps = site.getsitepackages(prefixes=[str(DEPS.resolve())])
+sys.path[0:0] = wilma_deps
+
+import wilma._bootstrap.run_module  # noqa
+from wilma._config import wilmaenv
+from wilma._inject import WilmaModuleWatchdog
+from wilma._inject import on_config_changed
 
 
 @contextmanager
@@ -45,10 +90,10 @@ try:
 
     # Install module watchdog
     try:
-        DebuggerModuleWatchdog.install()
+        WilmaModuleWatchdog.install()
     except RuntimeError:
         pass
-    atexit.register(DebuggerModuleWatchdog.uninstall)
+    atexit.register(WilmaModuleWatchdog.uninstall)
 
     # Create the Wilma prefix directory
     wilmaenv.wilmaprefix.mkdir(exist_ok=True)
@@ -67,6 +112,8 @@ try:
     # Initial configuration
     on_config_changed(wilmaenv.wilmaconfig)
 
-except WilmaException as e:
-    print(f"Cannot initialise Wilma: {e}", file=sys.stderr)
-    pass
+except WilmaException:
+    LOGGER.error("Cannot initialise Wilma", exc_info=True)
+
+# Remove Wilma dependencies from the path
+sys.path[: len(wilma_deps)] = []

--- a/wilma/_bootstrap/sitecustomize.py
+++ b/wilma/_bootstrap/sitecustomize.py
@@ -1,7 +1,16 @@
 import os
 import sys
 
+
+# Keep the runpy module to preserve the run module hooks.
+LOADED_MODULES = set(sys.modules.keys()) | {"sitecustomize", "runpy"}
+
 import preload  # noqa
+
+
+# Make sure to unload all that was loaded during the preload phase
+for module in set(sys.modules.keys()) - LOADED_MODULES:
+    del sys.modules[module]
 
 # Check for and import any sitecustomize that would have normally been used
 bootstrap_dir = os.path.abspath(os.path.dirname(__file__))

--- a/wilma/_deps.py
+++ b/wilma/_deps.py
@@ -61,6 +61,7 @@ class Dependencies:
                 env["PYTHONPATH"] = pythonpath
             else:
                 env["PYTHONPATH"] = ""
+            # TODO: Check for errors
             check_output(args, env=env)
 
             self.__installed__.update(deps)


### PR DESCRIPTION
With statically declared dependencies, Wilma might cause issues if used to debug any of them. This change tries to isolate Wilma dependencies from the rest of the environment by:
- downloading them at runtime in a dedicated prefix within a clean virtual environment
- unload the loaded dependencies to allow the target application to reload the appropriate versions of common dependencies, if required.